### PR TITLE
fix: add marketplace.json for plugin install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "sisyclaude",
+  "owner": {
+    "name": "Whiskey Tango Foxtrot GmbH"
+  },
+  "metadata": {
+    "description": "Multi-agent orchestration for Claude Code, ported from oh-my-openagent"
+  },
+  "plugins": [
+    {
+      "name": "sisyclaude",
+      "source": ".",
+      "description": "Greek mythology-themed agents for planning, execution, research, and review.",
+      "version": "2.1.0",
+      "repository": "https://github.com/Whiskey-Tango-Foxtrot-GmbH/sisyclaude",
+      "license": "Sustainable Use License v1.0",
+      "keywords": ["agents", "orchestration", "multi-agent", "planning"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ If you want the full experience with provider flexibility, go use [oh-my-openage
 ### As a Plugin
 
 ```bash
-/plugin install Whiskey-Tango-Foxtrot-GmbH/sisyclaude
+/plugin marketplace add Whiskey-Tango-Foxtrot-GmbH/sisyclaude
+/plugin install sisyclaude@sisyclaude
 ```
 
 ### Activate


### PR DESCRIPTION
## Summary
- Added `.claude-plugin/marketplace.json` so the repo works with `/plugin marketplace add owner/repo` syntax
- Updated README install instructions to use the correct two-step flow

## Context
`/plugin install Whiskey-Tango-Foxtrot-GmbH/sisyclaude` failed with "Marketplace not found" because the `owner/repo` syntax expects a `marketplace.json`, not just `plugin.json`.

## Test plan
- [ ] Run `/plugin marketplace add Whiskey-Tango-Foxtrot-GmbH/sisyclaude` — should succeed
- [ ] Run `/plugin install sisyclaude@sisyclaude` — should install the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)