### PR TITLE
fix: use valid source path in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "sisyclaude",
-      "source": ".",
+      "source": "./",
       "description": "Greek mythology-themed agents for planning, execution, research, and review.",
       "version": "2.1.0",
       "repository": "https://github.com/Whiskey-Tango-Foxtrot-GmbH/sisyclaude",


### PR DESCRIPTION
## Summary
- Fix `"source": "."` → `"source": "./"` in marketplace.json to pass schema validation
- The bare `"."` value causes `Invalid input` when installing via `claude /plugin marketplace add`

## Context
The marketplace schema rejects `"."` as a plugin source path. Other marketplace plugins use `"./"` or `"./plugins/name"` format. This single-character fix allows the plugin to be installed from the marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)