### PR TITLE
Activate via shell alias + system prompt file; drop @sisyphus sub-agent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "sisyclaude",
       "source": "./",
       "description": "Greek mythology-themed agents for planning, execution, research, and review.",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "repository": "https://github.com/Whiskey-Tango-Foxtrot-GmbH/sisyclaude",
       "license": "Sustainable Use License v1.0",
       "keywords": ["agents", "orchestration", "multi-agent", "planning"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sisyclaude",
   "description": "Multi-agent orchestration for Claude Code, ported from oh-my-openagent. Greek mythology-themed agents for planning, execution, research, and review.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": {
     "name": "Whiskey Tango Foxtrot GmbH"
   }

--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ The name "SisyClaude" is intentional — this is a reduced, Claude-specific adap
 
 If you want the full experience with provider flexibility, go use [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent). This port is for people who prefer (or need) to stay within Claude Code and want better orchestration than the vanilla experience.
 
+## Top-Level Orchestrator
+
+**Sisyphus** — Main orchestrator: classifies intent, delegates to specialists, verifies results. Runs at the top level (not a sub-agent, because the `Agent` tool cannot nest) and is loaded into Claude Code via the `sisyclaude` shell alias added by `/sisyclaude:activate`. Run `sisyclaude` instead of `claude` to start a session with Sisyphus's instructions in effect.
+
 ## Agents
 
 | Agent | Role | Model | Invocation |
 |---|---|---|---|
-| **Sisyphus** | Main orchestrator — classifies intent, delegates, verifies | Opus | `@sisyphus` |
 | **Atlas** | Plan executor — delegates ALL implementation, never codes | Opus | `@atlas` |
 | **Hephaestus** | Autonomous deep worker — never asks, just completes | Opus | `@hephaestus` |
 | **Prometheus** | Strategic planner — interviews, researches, writes plans | Opus | `@prometheus` |

--- a/agents/prometheus.md
+++ b/agents/prometheus.md
@@ -61,7 +61,7 @@ Here's why planning matters:
 3. Enables parallel work and delegation
 4. Ensures nothing is forgotten
 
-Let me quickly interview you to create a focused plan. Then use @sisyphus or @atlas to execute it immediately.
+Let me quickly interview you to create a focused plan. Then use @atlas to execute it immediately.
 
 This takes 2-3 minutes but saves hours of debugging.
 ```
@@ -159,7 +159,7 @@ CLEARANCE CHECKLIST:
 
 - **Metis consultation in progress** — "Consulting Metis for gap analysis..."
 - **Momus loop in progress** — "Momus rejected. Fixing issues and resubmitting..."
-- **Plan complete** — "Plan saved. Use @atlas or @sisyphus to begin execution."
+- **Plan complete** — "Plan saved. Use @atlas to begin execution."
 
 ---
 
@@ -416,7 +416,7 @@ while (true) {
 ## After Plan Completion: Cleanup & Handoff
 
 1. **Delete the draft file**: `Bash("rm .claude/drafts/{name}.md")`
-2. **Guide user**: "Plan saved to `.claude/plans/{name}.md`. Use @atlas or @sisyphus to begin execution."
+2. **Guide user**: "Plan saved to `.claude/plans/{name}.md`. Use @atlas to begin execution."
 
 ---
 
@@ -425,7 +425,7 @@ while (true) {
 - **Interview Mode**: Default — Consult, research, discuss. Run clearance check after each turn.
 - **Auto-Transition**: Clearance passes OR explicit trigger → Metis → Generate plan → Present summary
 - **Momus Loop**: If high accuracy requested → Loop until OKAY
-- **Handoff**: Tell user to invoke @atlas or @sisyphus for execution
+- **Handoff**: Tell user to invoke @atlas for execution
 
 ## Key Principles
 

--- a/skills/activate/SKILL.md
+++ b/skills/activate/SKILL.md
@@ -1,73 +1,84 @@
 ---
 name: activate
-description: Activate SisyClaude as the default Claude Code orchestrator by injecting its instructions into the user's global CLAUDE.md. Backs up existing CLAUDE.md if present.
+description: Activate SisyClaude by writing its system prompt to ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md and adding a `sisyclaude` shell alias that loads it via `claude --append-system-prompt-file`.
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Glob
 argument-hint:
 ---
 
-Activate SisyClaude as the default Claude Code orchestrator. Follow these steps exactly:
+Activate SisyClaude. The install does NOT patch `~/.claude/CLAUDE.md`. Instead it:
+
+1. Writes the Sisyphus instructions to `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md`.
+2. Adds a `sisyclaude` shell alias that runs `claude --append-system-prompt-file "$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"`.
+
+Follow these steps exactly.
 
 ## Step 1: Check if already activated
 
-Check if `~/.claude/CLAUDE.md` exists and already contains the SisyClaude marker:
-
 ```bash
-grep -q "SisyClaude orchestrator - installed by /sisyclaude:activate" ~/.claude/CLAUDE.md 2>/dev/null && echo "ALREADY_ACTIVE" || echo "NOT_ACTIVE"
+test -f ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md && echo "FILE_PRESENT" || echo "FILE_MISSING"
 ```
 
-If `ALREADY_ACTIVE`, tell the user SisyClaude is already activated and stop. Do not back up or overwrite.
+Then check the rc files for an existing alias block:
 
-## Step 2: Check for conflicting plugins
+```bash
+for f in ~/.zshrc ~/.bashrc ~/.bash_profile ~/.config/fish/config.fish; do
+  [ -f "$f" ] && grep -q "# >>> sisyclaude alias >>>" "$f" && echo "ALIAS_IN $f"
+done
+```
 
-Check if the `superpowers` plugin (from `claude-plugins-official`) is installed by looking for its SessionStart hook in settings:
+If both the system prompt file exists AND the alias is present in at least one rc file, tell the user SisyClaude is already activated and stop. Mention `/sisyclaude:deactivate` to remove it.
+
+If only one of the two is present, proceed — the missing piece will be added in the steps below.
+
+## Step 2: Detect and offer to clean up legacy install
+
+Older versions of this skill patched `~/.claude/CLAUDE.md` directly. Detect and offer to clean up:
+
+```bash
+grep -qE "Sisy(phus|Claude) orchestrator - installed by /sisy(phus|claude):activate" ~/.claude/CLAUDE.md 2>/dev/null && echo "LEGACY_PRESENT" || echo "NO_LEGACY"
+```
+
+If `LEGACY_PRESENT`, tell the user:
+
+> A legacy SisyClaude install is patched into `~/.claude/CLAUDE.md`. The new install does not touch that file. To avoid duplicate instructions, I can restore the oldest backup (`~/.claude/CLAUDE.md.backup.*`) to your CLAUDE.md before proceeding. Continue with restore? (recommended)
+
+If the user agrees, find the oldest backup and restore it:
+
+```bash
+oldest=$(ls -t ~/.claude/CLAUDE.md.backup.* 2>/dev/null | tail -1)
+[ -n "$oldest" ] && cp "$oldest" ~/.claude/CLAUDE.md && echo "Restored from $oldest"
+```
+
+If no backup exists, ask whether to delete `~/.claude/CLAUDE.md` outright or leave it as-is (duplicate instructions will be active during `sisyclaude` sessions but harmless).
+
+## Step 3: Check for conflicting plugins (superpowers)
 
 ```bash
 grep -r "superpowers" ~/.claude/settings.json ~/.claude/settings.local.json 2>/dev/null | head -5
-```
-
-Also check if a `using-superpowers` skill or `superpowers` hook exists in the project-level settings:
-
-```bash
 grep -r "superpowers" .claude/settings.json .claude/settings.local.json 2>/dev/null | head -5
 ```
 
-If **any match is found**, warn the user:
+If any match is found, warn the user:
 
 > **Warning: Conflicting plugin detected.**
 >
-> The `superpowers` plugin (from `claude-plugins-official`) uses aggressive SessionStart hooks that override SisyClaude's Phase 0 intent classification. When both are active, Claude will skip the think-first, delegate-first behavior and jump straight to action.
+> The `superpowers` plugin uses aggressive `SessionStart` hooks that inject instructions overriding SisyClaude's Phase 0 intent classification. With both active inside a `sisyclaude` session, Claude may skip the think-first, delegate-first behavior.
 >
 > **Options:**
-> 1. **Disable superpowers hooks** (recommended) — I'll comment out the superpowers SessionStart hook in your settings so it doesn't inject conflicting instructions. You can re-enable it with `/sisyclaude:deactivate`.
-> 2. **Continue anyway** — Keep both active, but expect degraded SisyClaude behavior.
-> 3. **Abort** — Stop activation.
+> 1. **Disable superpowers hooks** (recommended) — comment out the `SessionStart` hook entries referencing `superpowers`. Re-enable manually after `/sisyclaude:deactivate`.
+> 2. **Continue anyway** — keep both active, expect degraded behavior.
+> 3. **Abort** — stop activation.
 
-If the user chooses option 1, disable the superpowers SessionStart hook by reading the relevant settings file (global or project), removing or commenting out the hook entry that references `superpowers`, and writing the file back. Also create a marker file so deactivation knows to restore it:
+If option 1, remove or comment out the superpowers `SessionStart` hook entries in the relevant settings file, then mark it:
 
 ```bash
 echo "disabled_by_sisyclaude" > ~/.claude/.superpowers_disabled
 ```
 
-If the user chooses option 3, stop. Do not proceed with activation.
+If option 3, stop.
 
-## Step 3: Check for existing CLAUDE.md
-
-```bash
-test -f ~/.claude/CLAUDE.md && echo "EXISTS" || echo "NOT_FOUND"
-```
-
-## Step 4: Backup if it exists
-
-If the file exists, create a timestamped backup:
-
-```bash
-cp ~/.claude/CLAUDE.md ~/.claude/CLAUDE.md.backup.$(date +%Y%m%d_%H%M%S)
-```
-
-Tell the user the backup path.
-
-## Step 5: Read the Sisyphus agent definition
+## Step 4: Build the system prompt content
 
 Read the sisyphus agent file from the plugin:
 
@@ -75,23 +86,96 @@ Read the sisyphus agent file from the plugin:
 ${CLAUDE_SKILL_DIR}/../../agents/sisyphus.md
 ```
 
-## Step 6: Write CLAUDE.md
+Strip the YAML frontmatter (the leading `---` block with name/description/tools/model/color). Keep everything from `<Role>` onward.
 
-Create `~/.claude/CLAUDE.md` with the sisyphus agent content, but:
-- **Strip the YAML frontmatter** (the `---` block with name, description, tools, model, color)
-- **Keep everything else** (all the behavioral instructions from `<Role>` onward)
-- **Prepend a header comment** so the user knows where it came from:
+Prepend this header so the source is obvious:
 
 ```markdown
-<!-- SisyClaude orchestrator - installed by /sisyclaude:activate -->
-<!-- Original CLAUDE.md backed up. Run /sisyclaude:deactivate to restore. -->
+<!-- SisyClaude system prompt - installed by /sisyclaude:activate -->
+<!-- Loaded by the `sisyclaude` shell alias via `claude --append-system-prompt-file`. -->
+<!-- Run /sisyclaude:deactivate to remove the alias and this file. -->
 ```
 
-If the user already had content in their CLAUDE.md that they want to preserve (non-sisyclaude content), append a section break and the original content below the sisyphus instructions so nothing is lost.
+## Step 5: Write the system prompt file
 
-## Step 7: Confirm
+Write the combined content to `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md`. Overwrite if present (the legacy-cleanup step above already handled CLAUDE.md).
+
+## Step 6: Detect the user's shell and pick the rc file
+
+Use `$SHELL` to detect, fall back to checking `~/.zshrc`/`~/.bashrc` presence:
+
+```bash
+shell_name=$(basename "${SHELL:-}")
+uname_s=$(uname -s)
+
+case "$shell_name" in
+  zsh)
+    rc="$HOME/.zshrc"
+    style="posix"
+    ;;
+  bash)
+    # macOS bash conventionally uses .bash_profile for login shells.
+    if [ "$uname_s" = "Darwin" ] && [ -f "$HOME/.bash_profile" ]; then
+      rc="$HOME/.bash_profile"
+    elif [ -f "$HOME/.bashrc" ]; then
+      rc="$HOME/.bashrc"
+    elif [ "$uname_s" = "Darwin" ]; then
+      rc="$HOME/.bash_profile"
+    else
+      rc="$HOME/.bashrc"
+    fi
+    style="posix"
+    ;;
+  fish)
+    rc="$HOME/.config/fish/config.fish"
+    mkdir -p "$(dirname "$rc")"
+    style="fish"
+    ;;
+  *)
+    # Unknown shell — ask the user which rc file to edit, or default to ~/.profile.
+    rc="$HOME/.profile"
+    style="posix"
+    ;;
+esac
+
+echo "shell=$shell_name rc=$rc style=$style"
+```
+
+If the detected shell is unknown, tell the user what was detected and ask whether to write to `~/.profile` or a path they specify.
+
+## Step 7: Append the alias block
+
+Skip if the markers already exist in the chosen rc file:
+
+```bash
+grep -q "# >>> sisyclaude alias >>>" "$rc" 2>/dev/null && echo "ALREADY_HAS_ALIAS" || echo "NEEDS_ALIAS"
+```
+
+For POSIX shells (bash, zsh), append:
+
+```
+# >>> sisyclaude alias >>>
+alias sisyclaude='claude --append-system-prompt-file "$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"'
+# <<< sisyclaude alias <<<
+```
+
+For fish, append (note fish's alias syntax — space-separated, double-quoted):
+
+```
+# >>> sisyclaude alias >>>
+alias sisyclaude "claude --append-system-prompt-file \"$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md\""
+# <<< sisyclaude alias <<<
+```
+
+Use `printf '...\n' >> "$rc"` or the Write tool to append — do NOT overwrite.
+
+## Step 8: Confirm
 
 Tell the user:
-- SisyClaude is now the default orchestrator
-- Where the backup is (if one was made)
-- They can restore their original with `/sisyclaude:deactivate`
+
+- System prompt written to `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md`.
+- Alias `sisyclaude` added to `<rc file path>`.
+- They must reload their shell to use it: `source <rc file>` (or open a new terminal; fish users: `source <rc file>` works too).
+- Usage: run `sisyclaude` instead of `claude` to launch a session with the SisyClaude orchestrator instructions pre-loaded.
+- Plain `claude` is untouched — vanilla behavior is preserved.
+- Run `/sisyclaude:deactivate` (inside a Claude Code session) to remove the alias and the system prompt file.

--- a/skills/activate/SKILL.md
+++ b/skills/activate/SKILL.md
@@ -11,55 +11,44 @@ Activate SisyClaude. The install does NOT patch `~/.claude/CLAUDE.md`. Instead i
 1. Writes the Sisyphus instructions to `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md`.
 2. Adds a `sisyclaude` shell alias that runs `claude --append-system-prompt-file "$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"`.
 
-Follow these steps exactly.
+The mechanical work lives in adjacent scripts; this file orchestrates and handles user prompts.
 
-## Step 1: Check if already activated
+| File | Purpose |
+|---|---|
+| `check.sh` | Diagnoses current state (prompt file, alias, legacy install, superpowers) |
+| `restore-legacy.sh` | Restores the oldest `CLAUDE.md.backup.*` if a legacy install is present |
+| `install.sh` | Copies `system-prompt.md` to `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md`, detects shell, appends alias |
+| `system-prompt.md` | The full Sisyphus system prompt (loaded at top level — Sisyphus is not a sub-agent, since the Agent tool cannot nest) |
 
-```bash
-test -f ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md && echo "FILE_PRESENT" || echo "FILE_MISSING"
-```
-
-Then check the rc files for an existing alias block:
-
-```bash
-for f in ~/.zshrc ~/.bashrc ~/.bash_profile ~/.config/fish/config.fish; do
-  [ -f "$f" ] && grep -q "# >>> sisyclaude alias >>>" "$f" && echo "ALIAS_IN $f"
-done
-```
-
-If both the system prompt file exists AND the alias is present in at least one rc file, tell the user SisyClaude is already activated and stop. Mention `/sisyclaude:deactivate` to remove it.
-
-If only one of the two is present, proceed — the missing piece will be added in the steps below.
-
-## Step 2: Detect and offer to clean up legacy install
-
-Older versions of this skill patched `~/.claude/CLAUDE.md` directly. Detect and offer to clean up:
+## Step 1: Read current state
 
 ```bash
-grep -qE "Sisy(phus|Claude) orchestrator - installed by /sisy(phus|claude):activate" ~/.claude/CLAUDE.md 2>/dev/null && echo "LEGACY_PRESENT" || echo "NO_LEGACY"
+bash "${CLAUDE_SKILL_DIR}/check.sh"
 ```
 
-If `LEGACY_PRESENT`, tell the user:
+Parse the `key=value` output. Keys: `prompt_file`, `alias_in`, `legacy_claude_md`, `superpowers`.
+
+If `prompt_file=present` **and** `alias_in` is non-empty, SisyClaude is already activated. Tell the user and stop. Mention `/sisyclaude:deactivate` to remove it.
+
+If only one of the two is present, continue — the install script is idempotent and will fill in whatever's missing.
+
+## Step 2: Offer to clean up a legacy install
+
+If `legacy_claude_md=present`, tell the user:
 
 > A legacy SisyClaude install is patched into `~/.claude/CLAUDE.md`. The new install does not touch that file. To avoid duplicate instructions, I can restore the oldest backup (`~/.claude/CLAUDE.md.backup.*`) to your CLAUDE.md before proceeding. Continue with restore? (recommended)
 
-If the user agrees, find the oldest backup and restore it:
+If yes:
 
 ```bash
-oldest=$(ls -t ~/.claude/CLAUDE.md.backup.* 2>/dev/null | tail -1)
-[ -n "$oldest" ] && cp "$oldest" ~/.claude/CLAUDE.md && echo "Restored from $oldest"
+bash "${CLAUDE_SKILL_DIR}/restore-legacy.sh"
 ```
 
-If no backup exists, ask whether to delete `~/.claude/CLAUDE.md` outright or leave it as-is (duplicate instructions will be active during `sisyclaude` sessions but harmless).
+If the script prints `no_backup`, ask whether to delete `~/.claude/CLAUDE.md` outright or leave it as-is (duplicate instructions will be active during `sisyclaude` sessions but harmless).
 
-## Step 3: Check for conflicting plugins (superpowers)
+## Step 3: Handle superpowers conflict
 
-```bash
-grep -r "superpowers" ~/.claude/settings.json ~/.claude/settings.local.json 2>/dev/null | head -5
-grep -r "superpowers" .claude/settings.json .claude/settings.local.json 2>/dev/null | head -5
-```
-
-If any match is found, warn the user:
+If `superpowers=present`, warn the user:
 
 > **Warning: Conflicting plugin detected.**
 >
@@ -70,7 +59,7 @@ If any match is found, warn the user:
 > 2. **Continue anyway** — keep both active, expect degraded behavior.
 > 3. **Abort** — stop activation.
 
-If option 1, remove or comment out the superpowers `SessionStart` hook entries in the relevant settings file, then mark it:
+If option 1, remove or comment out the superpowers `SessionStart` hook entries in the relevant settings file, then mark it so deactivation knows:
 
 ```bash
 echo "disabled_by_sisyclaude" > ~/.claude/.superpowers_disabled
@@ -78,104 +67,33 @@ echo "disabled_by_sisyclaude" > ~/.claude/.superpowers_disabled
 
 If option 3, stop.
 
-## Step 4: Build the system prompt content
-
-Read the sisyphus agent file from the plugin:
-
-```
-${CLAUDE_SKILL_DIR}/../../agents/sisyphus.md
-```
-
-Strip the YAML frontmatter (the leading `---` block with name/description/tools/model/color). Keep everything from `<Role>` onward.
-
-Prepend this header so the source is obvious:
-
-```markdown
-<!-- SisyClaude system prompt - installed by /sisyclaude:activate -->
-<!-- Loaded by the `sisyclaude` shell alias via `claude --append-system-prompt-file`. -->
-<!-- Run /sisyclaude:deactivate to remove the alias and this file. -->
-```
-
-## Step 5: Write the system prompt file
-
-Write the combined content to `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md`. Overwrite if present (the legacy-cleanup step above already handled CLAUDE.md).
-
-## Step 6: Detect the user's shell and pick the rc file
-
-Use `$SHELL` to detect, fall back to checking `~/.zshrc`/`~/.bashrc` presence:
+## Step 4: Run the install
 
 ```bash
-shell_name=$(basename "${SHELL:-}")
-uname_s=$(uname -s)
-
-case "$shell_name" in
-  zsh)
-    rc="$HOME/.zshrc"
-    style="posix"
-    ;;
-  bash)
-    # macOS bash conventionally uses .bash_profile for login shells.
-    if [ "$uname_s" = "Darwin" ] && [ -f "$HOME/.bash_profile" ]; then
-      rc="$HOME/.bash_profile"
-    elif [ -f "$HOME/.bashrc" ]; then
-      rc="$HOME/.bashrc"
-    elif [ "$uname_s" = "Darwin" ]; then
-      rc="$HOME/.bash_profile"
-    else
-      rc="$HOME/.bashrc"
-    fi
-    style="posix"
-    ;;
-  fish)
-    rc="$HOME/.config/fish/config.fish"
-    mkdir -p "$(dirname "$rc")"
-    style="fish"
-    ;;
-  *)
-    # Unknown shell — ask the user which rc file to edit, or default to ~/.profile.
-    rc="$HOME/.profile"
-    style="posix"
-    ;;
-esac
-
-echo "shell=$shell_name rc=$rc style=$style"
+bash "${CLAUDE_SKILL_DIR}/install.sh"
 ```
 
-If the detected shell is unknown, tell the user what was detected and ask whether to write to `~/.profile` or a path they specify.
+Parse the output keys: `wrote`, `shell`, `rc`, `style`, `alias_status`.
 
-## Step 7: Append the alias block
+If the script exits non-zero or prints an `ERROR:` line on stderr, surface it to the user and stop — do not pretend the install succeeded.
 
-Skip if the markers already exist in the chosen rc file:
+If `shell=unknown` (i.e. `$SHELL` was unrecognised and the script fell back to `~/.profile`), tell the user what shell was detected and ask if `~/.profile` is correct or if they want a different rc file. If different, do the alias append manually using the same marker block style.
 
-```bash
-grep -q "# >>> sisyclaude alias >>>" "$rc" 2>/dev/null && echo "ALREADY_HAS_ALIAS" || echo "NEEDS_ALIAS"
-```
+## Step 5: Confirm — and tell the user what to do NEXT
 
-For POSIX shells (bash, zsh), append:
+Make the next-action steps prominent. The current Claude Code session does **not** pick up the new alias or system prompt — Sisyphus only takes effect in a fresh `sisyclaude` session. Spell this out:
 
-```
-# >>> sisyclaude alias >>>
-alias sisyclaude='claude --append-system-prompt-file "$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"'
-# <<< sisyclaude alias <<<
-```
-
-For fish, append (note fish's alias syntax — space-separated, double-quoted):
-
-```
-# >>> sisyclaude alias >>>
-alias sisyclaude "claude --append-system-prompt-file \"$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md\""
-# <<< sisyclaude alias <<<
-```
-
-Use `printf '...\n' >> "$rc"` or the Write tool to append — do NOT overwrite.
-
-## Step 8: Confirm
-
-Tell the user:
-
-- System prompt written to `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md`.
-- Alias `sisyclaude` added to `<rc file path>`.
-- They must reload their shell to use it: `source <rc file>` (or open a new terminal; fish users: `source <rc file>` works too).
-- Usage: run `sisyclaude` instead of `claude` to launch a session with the SisyClaude orchestrator instructions pre-loaded.
-- Plain `claude` is untouched — vanilla behavior is preserved.
-- Run `/sisyclaude:deactivate` (inside a Claude Code session) to remove the alias and the system prompt file.
+> **Install complete.**
+>
+> - System prompt written to `<value of wrote=>`.
+> - Alias `sisyclaude` was `<added | already present>` in `<value of rc=>`.
+>
+> **Next steps — do these now to activate Sisyphus:**
+>
+> 1. **Exit this Claude Code session** (`/exit`, Ctrl-D, or close the window). The current session was started with plain `claude`, so the new alias and system prompt are not loaded here.
+> 2. **Open a new terminal**, or reload your shell so the alias is on PATH:
+>    - bash/zsh: `source <value of rc=>`
+>    - fish: `source <value of rc=>`
+> 3. **Launch the new session** by running `sisyclaude` (instead of `claude`). That session loads Sisyphus via `--append-system-prompt-file`.
+>
+> Plain `claude` is left untouched — vanilla behaviour is preserved for any non-SisyClaude work. Run `/sisyclaude:deactivate` inside a Claude Code session any time to remove the alias and the system prompt file.

--- a/skills/activate/check.sh
+++ b/skills/activate/check.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Diagnostic for /sisyclaude:activate.
+# Prints line-oriented key=value state so SKILL.md can branch on the result.
+#
+# Keys:
+#   prompt_file=present|absent
+#   alias_in=<space-separated rc file paths, empty if none>
+#   legacy_claude_md=present|absent
+#   superpowers=present|absent
+
+set -u
+
+system_prompt="$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"
+legacy_claude_md="$HOME/.claude/CLAUDE.md"
+
+if [ -f "$system_prompt" ]; then
+  echo "prompt_file=present"
+else
+  echo "prompt_file=absent"
+fi
+
+alias_rcs=()
+for f in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile" "$HOME/.config/fish/config.fish"; do
+  [ -f "$f" ] || continue
+  if grep -q "# >>> sisyclaude alias >>>" "$f"; then
+    alias_rcs+=("$f")
+  fi
+done
+echo "alias_in=${alias_rcs[*]:-}"
+
+if grep -qE "Sisy(phus|Claude) orchestrator - installed by /sisy(phus|claude):activate" "$legacy_claude_md" 2>/dev/null; then
+  echo "legacy_claude_md=present"
+else
+  echo "legacy_claude_md=absent"
+fi
+
+if grep -rq "superpowers" "$HOME/.claude/settings.json" "$HOME/.claude/settings.local.json" 2>/dev/null \
+   || grep -rq "superpowers" ".claude/settings.json" ".claude/settings.local.json" 2>/dev/null; then
+  echo "superpowers=present"
+else
+  echo "superpowers=absent"
+fi

--- a/skills/activate/install.sh
+++ b/skills/activate/install.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Mechanical install for /sisyclaude:activate.
+# Copies system-prompt.md to ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md,
+# then appends the `sisyclaude` alias to the user's shell rc.
+#
+# Decisions that need user prompts (legacy cleanup, superpowers disable) are
+# handled by SKILL.md BEFORE this script runs.
+#
+# Output: line-oriented key=value so SKILL.md can report back to the user.
+#   wrote=<path to prompt file>
+#   shell=<bash|zsh|fish|unknown>
+#   rc=<path to rc file>
+#   style=<posix|fish>
+#   alias_status=added|already_present
+
+set -eu
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source_prompt="$here/system-prompt.md"
+prompt_file="$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"
+
+[ -f "$source_prompt" ] || { echo "ERROR: missing $source_prompt" >&2; exit 1; }
+
+mkdir -p "$(dirname "$prompt_file")"
+cp "$source_prompt" "$prompt_file"
+echo "wrote=$prompt_file"
+
+shell_name="$(basename "${SHELL:-}")"
+uname_s="$(uname -s)"
+
+case "$shell_name" in
+  zsh)
+    rc="$HOME/.zshrc"
+    style="posix"
+    ;;
+  bash)
+    # macOS bash conventionally uses .bash_profile for login shells.
+    if [ "$uname_s" = "Darwin" ] && [ -f "$HOME/.bash_profile" ]; then
+      rc="$HOME/.bash_profile"
+    elif [ -f "$HOME/.bashrc" ]; then
+      rc="$HOME/.bashrc"
+    elif [ "$uname_s" = "Darwin" ]; then
+      rc="$HOME/.bash_profile"
+    else
+      rc="$HOME/.bashrc"
+    fi
+    style="posix"
+    ;;
+  fish)
+    rc="$HOME/.config/fish/config.fish"
+    mkdir -p "$(dirname "$rc")"
+    style="fish"
+    ;;
+  *)
+    rc="$HOME/.profile"
+    style="posix"
+    ;;
+esac
+
+echo "shell=$shell_name"
+echo "rc=$rc"
+echo "style=$style"
+
+if [ -f "$rc" ] && grep -q "# >>> sisyclaude alias >>>" "$rc"; then
+  echo "alias_status=already_present"
+  exit 0
+fi
+
+if [ "$style" = "fish" ]; then
+  cat >> "$rc" <<'EOF'
+
+# >>> sisyclaude alias >>>
+alias sisyclaude "claude --append-system-prompt-file \"$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md\""
+# <<< sisyclaude alias <<<
+EOF
+else
+  cat >> "$rc" <<'EOF'
+
+# >>> sisyclaude alias >>>
+alias sisyclaude='claude --append-system-prompt-file "$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"'
+# <<< sisyclaude alias <<<
+EOF
+fi
+
+echo "alias_status=added"

--- a/skills/activate/restore-legacy.sh
+++ b/skills/activate/restore-legacy.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Restores the oldest ~/.claude/CLAUDE.md.backup.* over ~/.claude/CLAUDE.md.
+# Used when a legacy SisyClaude install patched CLAUDE.md and we want to undo it
+# before running the new install (which doesn't touch CLAUDE.md).
+#
+# Output:
+#   restored_from=<backup path>           # on success
+#   no_backup                             # if nothing to restore from
+
+set -u
+
+oldest=$(ls -t "$HOME"/.claude/CLAUDE.md.backup.* 2>/dev/null | tail -1)
+
+if [ -z "$oldest" ]; then
+  echo "no_backup"
+  exit 0
+fi
+
+cp "$oldest" "$HOME/.claude/CLAUDE.md"
+echo "restored_from=$oldest"

--- a/skills/activate/system-prompt.md
+++ b/skills/activate/system-prompt.md
@@ -1,11 +1,6 @@
----
-name: sisyphus
-description: Main orchestrator agent with full delegation capabilities. Classifies intent, delegates to specialists, verifies results. Use for complex tasks requiring planning, research, and multi-step execution. "Work yourself only when it is super simple." (Sisyphus - SisyClaude Plugin)
-tools: Read, Write, Edit, Grep, Glob, Bash, LSP, Agent, WebSearch, WebFetch, TodoWrite
-model: opus
-effort: high
-color: yellow
----
+<!-- SisyClaude system prompt - installed by /sisyclaude:activate -->
+<!-- Loaded by the `sisyclaude` shell alias via `claude --append-system-prompt-file`. -->
+<!-- Run /sisyclaude:deactivate to remove the alias and this file. -->
 
 <Role>
 You are "Sisyphus" - Powerful AI Agent with orchestration capabilities.

--- a/skills/deactivate/SKILL.md
+++ b/skills/deactivate/SKILL.md
@@ -13,67 +13,38 @@ Deactivate SisyClaude. The uninstall:
 
 It does NOT touch `~/.claude/CLAUDE.md` (the new install does not patch it).
 
-Follow these steps:
+The mechanical work lives in adjacent scripts; this file orchestrates and handles user prompts.
 
-## Step 1: Verify SisyClaude is active
+| File | Purpose |
+|---|---|
+| `check.sh` | Diagnoses current state (prompt file, alias rc files, superpowers marker) |
+| `uninstall.sh` | Strips the alias block from every rc file and deletes the prompt file |
 
-Check for either the system prompt file or the alias in any rc file:
-
-```bash
-found_file=0
-found_alias=0
-test -f ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md && found_file=1
-
-for f in ~/.zshrc ~/.bashrc ~/.bash_profile ~/.profile ~/.config/fish/config.fish; do
-  [ -f "$f" ] || continue
-  grep -q "# >>> sisyclaude alias >>>" "$f" && found_alias=1
-done
-
-echo "file=$found_file alias=$found_alias"
-```
-
-If both are `0`, tell the user SisyClaude is not currently activated and stop.
-
-If only one is present, proceed and clean up whatever remains.
-
-## Step 2: Remove the alias from every rc file that has it
-
-For each rc file containing the marker, strip the block between `# >>> sisyclaude alias >>>` and `# <<< sisyclaude alias <<<` (inclusive). Use `sed -i.bak` so a backup is left behind:
+## Step 1: Read current state
 
 ```bash
-removed_from=()
-for f in ~/.zshrc ~/.bashrc ~/.bash_profile ~/.profile ~/.config/fish/config.fish; do
-  [ -f "$f" ] || continue
-  if grep -q "# >>> sisyclaude alias >>>" "$f"; then
-    sed -i.bak '/# >>> sisyclaude alias >>>/,/# <<< sisyclaude alias <<</d' "$f"
-    removed_from+=("$f")
-  fi
-done
-printf 'Removed alias block from: %s\n' "${removed_from[@]:-<none>}"
+bash "${CLAUDE_SKILL_DIR}/check.sh"
 ```
 
-`sed -i.bak` is portable across macOS (BSD sed) and Linux (GNU sed) — both write the original to `<file>.bak`.
+Parse the `key=value` output. Keys: `prompt_file`, `alias_in`, `superpowers_marker`.
 
-Tell the user which files were edited and that `.bak` siblings were created in case they want to inspect or revert.
+If `prompt_file=absent` **and** `alias_in` is empty, SisyClaude is not currently activated. Tell the user and stop.
 
-## Step 3: Delete the system prompt file
+If only one is present, continue — the uninstall script will clean up whatever remains.
+
+## Step 2: Run the uninstall
 
 ```bash
-if [ -f ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md ]; then
-  rm -f ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md
-  echo "Removed ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"
-else
-  echo "No system prompt file to remove."
-fi
+bash "${CLAUDE_SKILL_DIR}/uninstall.sh"
 ```
 
-## Step 4: Check for disabled superpowers plugin
+Parse the output: `removed_from` (space-separated rc paths, possibly empty), `prompt_file` (`removed` or `already_absent`).
 
-```bash
-test -f ~/.claude/.superpowers_disabled && echo "WAS_DISABLED" || echo "NOT_DISABLED"
-```
+The script uses `sed -i.bak` so each edited rc file gets a `<file>.bak` sibling in case the user wants to inspect or revert.
 
-If `WAS_DISABLED`, ask the user whether to re-enable `superpowers` hooks. The exact settings entry varies, so tell them to check `~/.claude/settings.json` or `.claude/settings.json` and restore the `SessionStart` hook manually.
+## Step 3: Handle the superpowers marker
+
+If `superpowers_marker=present` from Step 1, ask the user whether to re-enable `superpowers` hooks. The exact settings entry varies, so tell them to check `~/.claude/settings.json` or `.claude/settings.json` and restore the `SessionStart` hook manually.
 
 Then remove the marker:
 
@@ -81,12 +52,12 @@ Then remove the marker:
 rm -f ~/.claude/.superpowers_disabled
 ```
 
-## Step 5: Confirm
+## Step 4: Confirm
 
 Tell the user:
 
-- The `sisyclaude` alias has been removed from `<list of rc files>` (backups at `<file>.bak`).
-- `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md` has been deleted (or note it was already absent).
+- The `sisyclaude` alias was removed from `<list from removed_from>` (backups at `<file>.bak`). If the list was empty, say nothing was removed from any rc.
+- `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md` was deleted (or note it was already absent).
 - They must reload their shell (`source <rc file>` or open a new terminal) for the alias to disappear from the current session.
 - `~/.claude/CLAUDE.md` was not touched — this version of the skill never modified it.
 - Re-activate any time with `/sisyclaude:activate`.

--- a/skills/deactivate/SKILL.md
+++ b/skills/deactivate/SKILL.md
@@ -1,52 +1,81 @@
 ---
 name: deactivate
-description: Deactivate SisyClaude by restoring the user's original CLAUDE.md from backup.
+description: Deactivate SisyClaude by removing the `sisyclaude` shell alias and deleting ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md.
 user-invocable: true
-allowed-tools: Read, Bash
+allowed-tools: Read, Edit, Bash
 argument-hint:
 ---
 
-Deactivate SisyClaude and restore the user's original CLAUDE.md. Follow these steps:
+Deactivate SisyClaude. The uninstall:
+
+1. Removes the `sisyclaude` alias block from every shell rc file that contains it.
+2. Deletes `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md`.
+
+It does NOT touch `~/.claude/CLAUDE.md` (the new install does not patch it).
+
+Follow these steps:
 
 ## Step 1: Verify SisyClaude is active
 
+Check for either the system prompt file or the alias in any rc file:
+
 ```bash
-grep -q "SisyClaude orchestrator - installed by /sisyclaude:activate" ~/.claude/CLAUDE.md 2>/dev/null && echo "ACTIVE" || echo "NOT_ACTIVE"
+found_file=0
+found_alias=0
+test -f ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md && found_file=1
+
+for f in ~/.zshrc ~/.bashrc ~/.bash_profile ~/.profile ~/.config/fish/config.fish; do
+  [ -f "$f" ] || continue
+  grep -q "# >>> sisyclaude alias >>>" "$f" && found_alias=1
+done
+
+echo "file=$found_file alias=$found_alias"
 ```
 
-If `NOT_ACTIVE`, tell the user SisyClaude is not currently activated and stop.
+If both are `0`, tell the user SisyClaude is not currently activated and stop.
 
-## Step 2: Find the oldest backup (the original)
+If only one is present, proceed and clean up whatever remains.
 
-Find the **oldest** backup — this is the user's original CLAUDE.md from before the first activation, not a backup of an already-activated state:
+## Step 2: Remove the alias from every rc file that has it
+
+For each rc file containing the marker, strip the block between `# >>> sisyclaude alias >>>` and `# <<< sisyclaude alias <<<` (inclusive). Use `sed -i.bak` so a backup is left behind:
 
 ```bash
-ls -t ~/.claude/CLAUDE.md.backup.* 2>/dev/null | tail -1
+removed_from=()
+for f in ~/.zshrc ~/.bashrc ~/.bash_profile ~/.profile ~/.config/fish/config.fish; do
+  [ -f "$f" ] || continue
+  if grep -q "# >>> sisyclaude alias >>>" "$f"; then
+    sed -i.bak '/# >>> sisyclaude alias >>>/,/# <<< sisyclaude alias <<</d' "$f"
+    removed_from+=("$f")
+  fi
+done
+printf 'Removed alias block from: %s\n' "${removed_from[@]:-<none>}"
 ```
 
-If no backup exists, tell the user there's nothing to restore — just delete `~/.claude/CLAUDE.md` if they want to remove SisyClaude.
+`sed -i.bak` is portable across macOS (BSD sed) and Linux (GNU sed) — both write the original to `<file>.bak`.
 
-## Step 3: Restore the backup
+Tell the user which files were edited and that `.bak` siblings were created in case they want to inspect or revert.
+
+## Step 3: Delete the system prompt file
 
 ```bash
-cp <oldest_backup> ~/.claude/CLAUDE.md
+if [ -f ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md ]; then
+  rm -f ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md
+  echo "Removed ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"
+else
+  echo "No system prompt file to remove."
+fi
 ```
 
 ## Step 4: Check for disabled superpowers plugin
-
-Check if SisyClaude previously disabled the superpowers plugin:
 
 ```bash
 test -f ~/.claude/.superpowers_disabled && echo "WAS_DISABLED" || echo "NOT_DISABLED"
 ```
 
-If `WAS_DISABLED`, ask the user:
+If `WAS_DISABLED`, ask the user whether to re-enable `superpowers` hooks. The exact settings entry varies, so tell them to check `~/.claude/settings.json` or `.claude/settings.json` and restore the `SessionStart` hook manually.
 
-> The `superpowers` plugin was disabled during SisyClaude activation. Would you like to re-enable it?
-
-If yes, the user will need to manually re-enable the superpowers hooks in their settings (since the exact hook configuration varies). Tell them where to look (`~/.claude/settings.json` or `.claude/settings.json`).
-
-Either way, clean up the marker:
+Then remove the marker:
 
 ```bash
 rm -f ~/.claude/.superpowers_disabled
@@ -55,7 +84,9 @@ rm -f ~/.claude/.superpowers_disabled
 ## Step 5: Confirm
 
 Tell the user:
-- Their original CLAUDE.md has been restored
-- The backup files are still there if they need them
-- Whether superpowers was re-enabled or still disabled
-- They can re-activate with `/sisyclaude:activate`
+
+- The `sisyclaude` alias has been removed from `<list of rc files>` (backups at `<file>.bak`).
+- `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md` has been deleted (or note it was already absent).
+- They must reload their shell (`source <rc file>` or open a new terminal) for the alias to disappear from the current session.
+- `~/.claude/CLAUDE.md` was not touched — this version of the skill never modified it.
+- Re-activate any time with `/sisyclaude:activate`.

--- a/skills/deactivate/check.sh
+++ b/skills/deactivate/check.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Diagnostic for /sisyclaude:deactivate.
+# Prints line-oriented key=value state.
+#
+# Keys:
+#   prompt_file=present|absent
+#   alias_in=<space-separated rc file paths, empty if none>
+#   superpowers_marker=present|absent
+
+set -u
+
+system_prompt="$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"
+
+if [ -f "$system_prompt" ]; then
+  echo "prompt_file=present"
+else
+  echo "prompt_file=absent"
+fi
+
+alias_rcs=()
+for f in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile" "$HOME/.config/fish/config.fish"; do
+  [ -f "$f" ] || continue
+  if grep -q "# >>> sisyclaude alias >>>" "$f"; then
+    alias_rcs+=("$f")
+  fi
+done
+echo "alias_in=${alias_rcs[*]:-}"
+
+if [ -f "$HOME/.claude/.superpowers_disabled" ]; then
+  echo "superpowers_marker=present"
+else
+  echo "superpowers_marker=absent"
+fi

--- a/skills/deactivate/uninstall.sh
+++ b/skills/deactivate/uninstall.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Mechanical uninstall for /sisyclaude:deactivate.
+# Strips the alias block from every rc file that contains it (using sed -i.bak
+# for portability between BSD and GNU sed) and deletes the system prompt file.
+#
+# Output: line-oriented key=value.
+#   removed_from=<space-separated rc paths, empty if none>
+#   prompt_file=removed|already_absent
+
+set -u
+
+system_prompt="$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"
+
+removed_from=()
+for f in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile" "$HOME/.config/fish/config.fish"; do
+  [ -f "$f" ] || continue
+  if grep -q "# >>> sisyclaude alias >>>" "$f"; then
+    sed -i.bak '/# >>> sisyclaude alias >>>/,/# <<< sisyclaude alias <<</d' "$f"
+    removed_from+=("$f")
+  fi
+done
+echo "removed_from=${removed_from[*]:-}"
+
+if [ -f "$system_prompt" ]; then
+  rm -f "$system_prompt"
+  echo "prompt_file=removed"
+else
+  echo "prompt_file=already_absent"
+fi


### PR DESCRIPTION
## Summary

- **Install no longer patches `~/.claude/CLAUDE.md`.** `/sisyclaude:activate` now writes the Sisyphus instructions to `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md` and adds a `sisyclaude` shell alias that runs `claude --append-system-prompt-file ...`. Plain `claude` stays vanilla; users opt in via the new command.
- **Sisyphus is no longer a sub-agent.** `agents/sisyphus.md` is removed (renamed into `skills/activate/system-prompt.md`). Claude Code's `Agent` tool cannot nest — a sub-agent named `sisyphus` could never have delegated to other agents, which is its entire purpose. The role now lives only at the top level, where `Agent()` works as intended. Prometheus handoff lines and the README table updated to drop `@sisyphus`; planner now hands off to `@atlas` only.
- **Install/uninstall internals extracted from `SKILL.md`** into adjacent scripts (`check.sh`, `install.sh`, `restore-legacy.sh`, `uninstall.sh`) and an adjacent template (`system-prompt.md`). `SKILL.md` is now a thin orchestrator that parses `key=value` script output and handles user-facing decisions (legacy-CLAUDE.md cleanup, superpowers conflict).
- **Shell detection** picks the right rc file for zsh / bash (macOS uses `.bash_profile`, Linux uses `.bashrc`) / fish; unknown shells fall back to `~/.profile`. Alias block is guarded by `# >>> sisyclaude alias >>>` markers so deactivate can strip it cleanly with `sed -i.bak` (BSD/GNU portable).
- **Post-install confirmation** now spells out the next-action sequence: exit the current Claude Code session, source the rc (or open a new terminal), then run `sisyclaude`. The current session does not pick up the new prompt — important to call out.
- **Legacy migration path**: activate detects an old CLAUDE.md-patched install, offers to restore the oldest `CLAUDE.md.backup.*`, then proceeds with the new flow.
- **Version bumped** to 2.3.0 in `plugin.json` and `marketplace.json`.

## Test plan

- [ ] Fresh install on zsh (macOS): `/sisyclaude:activate` writes `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md` and appends the alias block to `~/.zshrc`. New terminal: `sisyclaude` launches with Sisyphus loaded.
- [ ] Fresh install on bash (Linux): alias lands in `~/.bashrc`.
- [ ] Fresh install on bash (macOS): alias lands in `~/.bash_profile`.
- [ ] Fresh install on fish: alias lands in `~/.config/fish/config.fish` with fish's space-separated alias syntax.
- [ ] Legacy migration: with a CLAUDE.md that contains the old `Sisyphus orchestrator - installed by /sisyphus:activate` marker, activate offers to restore the oldest backup before proceeding.
- [ ] Superpowers conflict: when `superpowers` is detected in settings, activate warns and offers to disable.
- [ ] Idempotency: running activate twice does not duplicate the alias block (`alias_status=already_present`).
- [ ] `/sisyclaude:deactivate` removes the alias block from every rc file that contains it (leaving `.bak` siblings), deletes `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md`, and offers to re-enable superpowers if it was previously disabled.
- [ ] Inside a `sisyclaude` session, Sisyphus can delegate via `Agent(subagent_type="explore")` etc. (confirming the top-level placement actually fixes the nesting issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)