### PR TITLE
feat: replace default system prompt instead of appending (v2.3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "sisyclaude",
       "source": "./",
       "description": "Greek mythology-themed agents for planning, execution, research, and review.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "repository": "https://github.com/Whiskey-Tango-Foxtrot-GmbH/sisyclaude",
       "license": "Sustainable Use License v1.0",
       "keywords": ["agents", "orchestration", "multi-agent", "planning"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sisyclaude",
   "description": "Multi-agent orchestration for Claude Code, ported from oh-my-openagent. Greek mythology-themed agents for planning, execution, research, and review.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Whiskey Tango Foxtrot GmbH"
   }

--- a/skills/activate/SKILL.md
+++ b/skills/activate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: activate
-description: Activate SisyClaude by writing its system prompt to ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md and adding a `sisyclaude` shell alias that loads it via `claude --append-system-prompt-file`.
+description: Activate SisyClaude by writing its system prompt to ~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md and adding a `sisyclaude` shell alias that loads it via `claude --system-prompt-file` (replaces the default Claude Code system prompt for that session).
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Glob
 argument-hint:
@@ -9,7 +9,7 @@ argument-hint:
 Activate SisyClaude. The install does NOT patch `~/.claude/CLAUDE.md`. Instead it:
 
 1. Writes the Sisyphus instructions to `~/.claude/SISYCLAUDE_SYSTEM_PROMPT.md`.
-2. Adds a `sisyclaude` shell alias that runs `claude --append-system-prompt-file "$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"`.
+2. Adds a `sisyclaude` shell alias that runs `claude --system-prompt-file "$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"`. This **replaces** Claude Code's default system prompt for `sisyclaude` sessions — Sisyphus is the entire system prompt, not an addition.
 
 The mechanical work lives in adjacent scripts; this file orchestrates and handles user prompts.
 
@@ -94,6 +94,6 @@ Make the next-action steps prominent. The current Claude Code session does **not
 > 2. **Open a new terminal**, or reload your shell so the alias is on PATH:
 >    - bash/zsh: `source <value of rc=>`
 >    - fish: `source <value of rc=>`
-> 3. **Launch the new session** by running `sisyclaude` (instead of `claude`). That session loads Sisyphus via `--append-system-prompt-file`.
+> 3. **Launch the new session** by running `sisyclaude` (instead of `claude`). That session loads Sisyphus via `--system-prompt-file`, replacing Claude Code's default system prompt for that session.
 >
 > Plain `claude` is left untouched — vanilla behaviour is preserved for any non-SisyClaude work. Run `/sisyclaude:deactivate` inside a Claude Code session any time to remove the alias and the system prompt file.

--- a/skills/activate/install.sh
+++ b/skills/activate/install.sh
@@ -70,14 +70,14 @@ if [ "$style" = "fish" ]; then
   cat >> "$rc" <<'EOF'
 
 # >>> sisyclaude alias >>>
-alias sisyclaude "claude --append-system-prompt-file \"$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md\""
+alias sisyclaude "claude --system-prompt-file \"$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md\""
 # <<< sisyclaude alias <<<
 EOF
 else
   cat >> "$rc" <<'EOF'
 
 # >>> sisyclaude alias >>>
-alias sisyclaude='claude --append-system-prompt-file "$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"'
+alias sisyclaude='claude --system-prompt-file "$HOME/.claude/SISYCLAUDE_SYSTEM_PROMPT.md"'
 # <<< sisyclaude alias <<<
 EOF
 fi

--- a/skills/activate/system-prompt.md
+++ b/skills/activate/system-prompt.md
@@ -1,5 +1,5 @@
 <!-- SisyClaude system prompt - installed by /sisyclaude:activate -->
-<!-- Loaded by the `sisyclaude` shell alias via `claude --append-system-prompt-file`. -->
+<!-- Loaded by the `sisyclaude` shell alias via `claude --system-prompt-file`. -->
 <!-- Run /sisyclaude:deactivate to remove the alias and this file. -->
 
 <Role>


### PR DESCRIPTION
## Summary
- Switch the `sisyclaude` alias from `claude --append-system-prompt-file` to `claude --system-prompt-file`, so Sisyphus *replaces* Claude Code's default system prompt for that session instead of stacking on top of it.
- Update the install script, `/sisyclaude:activate` skill docs, and the on-disk prompt header to reflect the new flag.
- Bump version: 2.3.0 → 2.3.1 (in `.claude-plugin/plugin.json` and `marketplace.json`).

## Test plan
- [ ] Run `/sisyclaude:activate` in a fresh shell, confirm alias line uses `--system-prompt-file`.
- [ ] Open a new terminal, run `sisyclaude`, verify the Sisyphus role is active and Claude Code's default behaviors are not duplicated.
- [ ] Run `/sisyclaude:deactivate` and confirm alias + prompt file are cleanly removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)